### PR TITLE
Reseting flags in compareWithCurrentDoc on subsequent calls

### DIFF
--- a/model/document.js
+++ b/model/document.js
@@ -411,6 +411,7 @@ module.exports = class BaseDocument extends Observable {
       }
 
       // set submit action flag
+      this.flags = {}
       if (this.submitted && !currentDoc.submitted) {
         this.flags.submitAction = true;
       }


### PR DESCRIPTION
@ankitsinghaniyaz added the code to reset the flags in CompareWithCurrentDoc